### PR TITLE
[fix] 무한스크롤 조건 훅 축제갯수 8개로 정상화, 축제카드 렌더링 useCallback->useEffect로 변경

### DIFF
--- a/src/hooks/useFestivalList.ts
+++ b/src/hooks/useFestivalList.ts
@@ -15,7 +15,7 @@ export function useInfiniteFestivalList(params: GetFestivalListParams = {}) {
     queryKey: ["festivalsInfinite", params],
     queryFn: ({ pageParam = 1 }) => fetchFestivalList({ ...params, pageNo: pageParam as number }),
     getNextPageParam: (lastPage, allPages) =>
-      lastPage.item.length === 4 ? allPages.length + 1 : undefined, // 16: numOfRows
+      lastPage.item.length === 8 ? allPages.length + 1 : undefined, // 16: numOfRows
     initialPageParam: 1,
     staleTime: 1000 * 60,
   });
@@ -28,7 +28,7 @@ export function useInfiniteFestivalSearch(keyword: string, lang = "kor") {
     queryFn: ({ pageParam = 1 }) => fetchFestivalSearch(keyword, lang, pageParam as number),
     enabled: !!keyword,
     getNextPageParam: (lastPage, allPages) =>
-      lastPage.item.length === 4 ? allPages.length + 1 : undefined,
+      lastPage.item.length === 8 ? allPages.length + 1 : undefined,
     initialPageParam: 1,
     staleTime: 1000 * 60,
   });

--- a/src/pages/Festival/components/FestivalGrid.tsx
+++ b/src/pages/Festival/components/FestivalGrid.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState,  useEffect } from "react";
 import { useFestivalOverview, useFestivalPeriod } from "../../../hooks/useFestivalList";
 import { Link } from "react-router-dom";
 import { Heart, MapPin, Calendar } from "lucide-react";
@@ -79,7 +79,7 @@ function FestivalCard({
   // const ended = isFestivalEnded(eventEnd);
 
   // fetch된 값이 있으면 상위로 올려줌 (부모 state 업데이트)
-  useCallback(() => {
+  useEffect(() => {
     if (!infoLoading && !periodLoading && (overview || formattedPeriod)) {
       onUpdateDetails((prev) =>
         prev[festival.id]?.period === formattedPeriod &&
@@ -96,7 +96,7 @@ function FestivalCard({
             }
       );
     }
-  }, [infoLoading, periodLoading, formattedPeriod, overview, festival.id, eventEnd, onUpdateDetails])();
+  }, [infoLoading, periodLoading, formattedPeriod, overview, festival.id, eventEnd, onUpdateDetails]);
  
   return (
     <div


### PR DESCRIPTION
## #️⃣Issue Number

> ex) #37 

## 📝Summary

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

### 📸Screenshot

> 스크린샷