### PR TITLE
[fix] req.body를 fetch에 넘기는 대신, req객체 자체를 fetch의 body에 duplex: half와 함…

### DIFF
--- a/api/proxy.ts
+++ b/api/proxy.ts
@@ -1,8 +1,7 @@
+// /api/proxy.ts
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 
-/**
- * 헤더 변환 (host, content-length 제거)
- */
+// host, content-length 등 제거
 function getHeaders(headersObj: VercelRequest["headers"]): Record<string, string> {
   const headers: Record<string, string> = {};
   Object.entries(headersObj).forEach(([key, value]) => {
@@ -20,8 +19,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     res.status(400).send("Missing target URL");
     return;
   }
-
-  // 쿼리 파라미터 재조합
   const paramString = Object.entries(params)
     .filter(([k, v]) => v !== undefined && v !== "" && k !== "url")
     .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v as string)}`)
@@ -29,23 +26,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const backendUrl =
     decodeURIComponent(url) + (paramString ? (url.includes("?") ? "&" : "?") + paramString : "");
 
-  console.log("[Vercel Proxy] 실제 요청하는 백엔드 URL:", backendUrl);
-
-  // 헤더 준비 (content-length, host 제거)
   const headers = getHeaders(req.headers);
 
-  // body 준비 (multipart는 Buffer로 전달됨. 그대로 전송!)
-  let body: Buffer | string | undefined = undefined;
-  if (req.method !== "GET" && req.method !== "HEAD") {
-    // Vercel에서는 req.body가 이미 Buffer로 들어오므로, 별도 변환 없이 그대로 전달
-    body = req.body;
-  }
-
+  // [핵심] req.body 대신 req (readable stream)를 그대로 fetch의 body에 넘기기
+  // Node.js 18 이상 fetch에서 ReadableStream 지원됨 (Vercel 런타임도 지원)
   try {
     const fetchRes = await fetch(backendUrl, {
       method: req.method,
       headers,
-      body,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      body: req.method === "GET" || req.method === "HEAD" ? undefined : (req as any),
+        // @ts-expect-error: duplex is required for streaming in Node.js fetch, but not in types
+
+      duplex: "half", // Node.js fetch에 Stream 쓰려면 반드시 duplex: "half" 필요
     });
     res.status(fetchRes.status);
     fetchRes.headers.forEach((v, k) => res.setHeader(k, v));


### PR DESCRIPTION
…께 직접 사용함으로써 multipart/form-data 깨지는 에러 해결

## #️⃣Issue Number

> ex) #46 

## 📝Summary

> 1. 기존엔
    - `body = req.body` (Buffer, string, object 등 구분 불명확)
    - `JSON.stringify(req.body)` → multipart일 때 절대 쓰면 안 됨 (boundary와 파일 깨짐)
    - multipart를 raw로 전달해야 하는데, req.body가 변형되어 버림
    - 결과적으로 백엔드에서 파싱 실패 (500에러)
2. 지금은
    - req (stream)를 fetch에 직접 전달, 아무런 변형 없이 원본 보존(+duplex: half)
    - 파일, 텍스트, boundary, 모든 form-data가 깨지지 않고 그대로 전달됨
    - 백엔드는 원래대로 잘 파싱

### 📸Screenshot

> 스크린샷